### PR TITLE
feat: add id to queue send response

### DIFF
--- a/proto/queue/v1/queue.proto
+++ b/proto/queue/v1/queue.proto
@@ -33,7 +33,12 @@ message QueueSendRequest {
 }
 
 // Result of pushing a single task to a queue
-message QueueSendResponse {}
+message QueueSendResponse {
+  // The id of the published message
+  // When an id was not supplied
+  // one should be automatically generated
+  string id = 1;
+}
 
 message QueueSendBatchRequest {
   // The Nitric name for the queue


### PR DESCRIPTION
Leaving this here as a trigger for a discussion. Should we include the auto-generated ids in the response from send and send batch?

Also, we should probably remove the Send/SendBatch separation in these contracts. We can implement a 'send' in the SDKs to simplify the interface instead.